### PR TITLE
Parallel decoding

### DIFF
--- a/lib/decoding/code_section_parser.ex
+++ b/lib/decoding/code_section_parser.ex
@@ -6,15 +6,12 @@ defmodule WaspVM.Decoder.CodeSectionParser do
 
   @moduledoc false
 
-  def parse(module) do
-    {count, bodies} =
-      module.sections
-      |> Map.get(10)
-      |> LEB128.decode_unsigned()
+  def parse(section) do
+    {count, bodies} = LEB128.decode_unsigned(section)
 
     bodies = if count > 0, do: parse_bodies(bodies), else: []
 
-    Map.put(module, :functions, Enum.reverse(bodies))
+    {:functions, Enum.reverse(bodies)}
   end
 
   defp parse_bodies(bodies), do: parse_bodies([], bodies)

--- a/lib/decoding/custom_section_parser.ex
+++ b/lib/decoding/custom_section_parser.ex
@@ -4,19 +4,16 @@ defmodule WaspVM.Decoder.CustomSectionParser do
 
   @moduledoc false
 
-  def parse(module) do
-    {name_len, rest} =
-      module.sections
-      |> Map.get(0)
-      |> LEB128.decode_unsigned()
+  def parse(section) do
+    {name_len, rest} = LEB128.decode_unsigned(section)
 
     <<name::bytes-size(name_len), rest::binary>> = rest
 
     section = parse_section(name, rest)
 
-    custom = Map.put(module.custom, String.to_atom(name), section)
+    custom = Map.new([{String.to_atom(name), section}])
 
-    Map.put(module, :custom, custom)
+    {:custom, custom}
   end
 
   def parse_section("name", binary), do: NameSectionParser.parse(binary)

--- a/lib/decoding/decoder.ex
+++ b/lib/decoding/decoder.ex
@@ -23,7 +23,7 @@ defmodule WaspVM.Decoder do
   end
 
   @doc false
-  def decode(bin) when is_binary(bin), do: do_decode(%Module{}, bin)
+  def decode(bin) when is_binary(bin), do: split_sections(%Module{}, bin)
 
   @doc false
   def decode(bin) do
@@ -31,37 +31,41 @@ defmodule WaspVM.Decoder do
     raise "Invalid data provided for #{fun}/#{arity}. Must be binary, got: #{inspect(bin)}"
   end
 
-  defp do_decode(module, <<>>), do: module
+  defp split_sections(module, <<>>), do: parallel_decode(module)
 
-  defp do_decode(module, bin) when module == %Module{} do
+  defp split_sections(module, bin) when module == %Module{} do
     <<magic::bytes-size(4), version::bytes-size(4), rest::binary>> = bin
 
     if magic != <<0, 97, 115, 109>> do
       raise "Malformed or incomplete binary"
     else
-      do_decode(%Module{magic: magic, version: version}, rest)
+      split_sections(%Module{magic: magic, version: version}, rest)
     end
   end
 
-  defp do_decode(module, bin) do
+  defp split_sections(module, bin) do
     <<section_code, rest::binary>> = bin
 
-    {unparsed_section, rest} = decode_section(section_code, rest)
+    {unparsed_section, rest} = split_section(section_code, rest)
 
-    module =
-      module
-      |> Module.add_section(section_code, unparsed_section)
-      |> parse_section(section_code)
+    module = Module.add_section(module, section_code, unparsed_section)
 
-    do_decode(module, rest)
+    split_sections(module, rest)
   end
 
-  defp decode_section(sec_code, bin) when sec_code >= 0 do
+  defp split_section(sec_code, bin) when sec_code >= 0 do
     {size, rest} = LEB128.decode_unsigned(bin)
 
     <<section::bytes-size(size), rest::binary>> = rest
 
     {section, rest}
+  end
+
+  defp parallel_decode(module) do
+    module.sections
+    |> Enum.map(fn {k, _} -> Task.async(fn -> parse_section(module, k) end) end)
+    |> Enum.map(&Task.await/1)
+    |> Enum.reduce(& Map.merge(&2, &1))
   end
 
   defp parse_section(module, 0), do: CustomSectionParser.parse(module)

--- a/lib/decoding/decoder.ex
+++ b/lib/decoding/decoder.ex
@@ -63,22 +63,26 @@ defmodule WaspVM.Decoder do
 
   defp parallel_decode(module) do
     module.sections
-    |> Enum.map(fn {k, _} -> Task.async(fn -> parse_section(module, k) end) end)
-    |> Enum.map(&Task.await/1)
-    |> Enum.reduce(& Map.merge(&2, &1))
+    |> Task.async_stream(&parse_section/1)
+    |> Enum.reduce(module, fn {k, v}, a -> Map.put(a, k, v) end)
+
+    # module.sections
+    # |> Stream.map(fn {k, _} -> Task.async(fn -> parse_section(module, k) end) end)
+    # |> Stream.map(&Task.await/1)
+    # |> Enum.reduce(&Map.merge(&2, &1))
   end
 
-  defp parse_section(module, 0), do: CustomSectionParser.parse(module)
-  defp parse_section(module, 1), do: TypeSectionParser.parse(module)
-  defp parse_section(module, 2), do: ImportSectionParser.parse(module)
-  defp parse_section(module, 3), do: FunctionSectionParser.parse(module)
-  defp parse_section(module, 4), do: TableSectionParser.parse(module)
-  defp parse_section(module, 5), do: MemorySectionParser.parse(module)
-  defp parse_section(module, 6), do: GlobalSectionParser.parse(module)
-  defp parse_section(module, 7), do: ExportSectionParser.parse(module)
-  defp parse_section(module, 8), do: StartSectionParser.parse(module)
-  defp parse_section(module, 9), do: ElementSectionParser.parse(module)
-  defp parse_section(module, 10), do: CodeSectionParser.parse(module)
-  defp parse_section(module, _), do: module
+  defp parse_section({0, section}), do: CustomSectionParser.parse(section)
+  defp parse_section({1, section}), do: TypeSectionParser.parse(section)
+  defp parse_section({2, section}), do: ImportSectionParser.parse(section)
+  defp parse_section({3, section}), do: FunctionSectionParser.parse(section)
+  defp parse_section({4, section}), do: TableSectionParser.parse(section)
+  defp parse_section({5, section}), do: MemorySectionParser.parse(section)
+  defp parse_section({6, section}), do: GlobalSectionParser.parse(section)
+  defp parse_section({7, section}), do: ExportSectionParser.parse(section)
+  defp parse_section({8, section}), do: StartSectionParser.parse(section)
+  defp parse_section({9, section}), do: ElementSectionParser.parse(section)
+  defp parse_section({10, section}), do: CodeSectionParser.parse(section)
+  defp parse_section({_, section}), do: section
 
 end

--- a/lib/decoding/decoder.ex
+++ b/lib/decoding/decoder.ex
@@ -16,41 +16,52 @@ defmodule WaspVM.Decoder do
 
   @moduledoc false
 
-  def decode_file(file_path) do
+  def decode_file(file_path, parallel) do
     {:ok, bin} = File.read(file_path)
 
-    decode(bin)
+    decode(bin, parallel)
   end
 
   @doc false
-  def decode(bin) when is_binary(bin), do: split_sections(%Module{}, bin)
+  def decode(bin, parallel) when is_binary(bin), do: begin_split(%Module{}, bin, parallel)
 
   @doc false
-  def decode(bin) do
+  def decode(bin, _parallel) do
     {fun, arity} = __ENV__.function
     raise "Invalid data provided for #{fun}/#{arity}. Must be binary, got: #{inspect(bin)}"
   end
 
-  defp split_sections(module, <<>>), do: parallel_decode(module)
-
-  defp split_sections(module, bin) when module == %Module{} do
+  defp begin_split(module, bin, parallel) do
     <<magic::bytes-size(4), version::bytes-size(4), rest::binary>> = bin
 
     if magic != <<0, 97, 115, 109>> do
       raise "Malformed or incomplete binary"
     else
-      split_sections(%Module{magic: magic, version: version}, rest)
+      split_sections(%Module{magic: magic, version: version}, rest, parallel)
     end
   end
 
-  defp split_sections(module, bin) do
+  defp split_sections(module, <<>>, true), do: parallel_decode(module)
+  defp split_sections(module, <<>>, false), do: module
+
+  defp split_sections(module, bin, parallel) do
     <<section_code, rest::binary>> = bin
 
     {unparsed_section, rest} = split_section(section_code, rest)
 
     module = Module.add_section(module, section_code, unparsed_section)
 
-    split_sections(module, rest)
+    module =
+      if !parallel do
+        section = Map.get(module.sections, section_code)
+        {k, v} = parse_section({section_code, section})
+
+        Map.put(module, k, v)
+      else
+        module
+      end
+
+    split_sections(module, rest, parallel)
   end
 
   defp split_section(sec_code, bin) when sec_code >= 0 do

--- a/lib/decoding/element_section_parser.ex
+++ b/lib/decoding/element_section_parser.ex
@@ -4,17 +4,14 @@ defmodule WaspVM.Decoder.ElementSectionParser do
 
   @moduledoc false
 
-  def parse(module) do
+  def parse(section) do
     raise "Element section parser not implemented"
 
-    {count, entries} =
-      module.sections
-      |> Map.get(9)
-      |> LEB128.decode_unsigned()
+    {count, entries} = LEB128.decode_unsigned(section)
 
     entries = if count > 0, do: parse_entries(entries), else: []
 
-    Map.put(module, :elements, entries)
+    {:elements, entries}
   end
 
   defp parse_entries(entries), do: parse_entries([], entries)

--- a/lib/decoding/export_section_parser.ex
+++ b/lib/decoding/export_section_parser.ex
@@ -5,16 +5,13 @@ defmodule WaspVM.Decoder.ExportSectionParser do
 
   @moduledoc false
 
-  def parse(module) do
-    {count, entries} =
-      module.sections
-      |> Map.get(7)
-      |> LEB128.decode_unsigned()
+  def parse(section) do
+    {count, entries} = LEB128.decode_unsigned(section)
 
     entries = if count > 0, do: parse_entries(entries), else: []
     entries = entries |> Enum.reject(&(&1 == nil))
 
-    Map.put(module, :exports, Enum.reverse(entries))
+    {:exports, Enum.reverse(entries)}
   end
 
   defp parse_entries(entries), do: parse_entries([], entries)

--- a/lib/decoding/function_section_parser.ex
+++ b/lib/decoding/function_section_parser.ex
@@ -3,12 +3,10 @@ defmodule WaspVM.Decoder.FunctionSectionParser do
 
   @moduledoc false
 
-  @spec parse(WaspVM.Module) :: WaspVM.Module
-  def parse(module) do
-    values = Map.get(module.sections, 3)
-    indexes = if values !== nil, do: parse_type_entry(values), else: []
+  def parse(section) do
+    indexes = if section !== nil, do: parse_type_entry(section), else: []
 
-    Map.put(module, :function_types, Enum.reverse(indexes))
+    {:function_types, Enum.reverse(indexes)}
   end
 
   @spec parse_type_entry(Binary) :: List

--- a/lib/decoding/global_section_parser.ex
+++ b/lib/decoding/global_section_parser.ex
@@ -7,15 +7,12 @@ defmodule WaspVM.Decoder.GlobalSectionParser do
 
   @moduledoc false
 
-  def parse(module) do
-    {count, entries} =
-      module.sections
-      |> Map.get(6)
-      |> LEB128.decode_unsigned()
+  def parse(section) do
+    {count, entries} = LEB128.decode_unsigned(section)
 
     globals = if count > 0, do: Enum.reverse(parse_entries(entries)), else: []
 
-    Map.put(module, :globals, globals)
+    {:globals, globals}
   end
 
   defp parse_entries(entries), do: parse_entries([], entries)

--- a/lib/decoding/import_section_parser.ex
+++ b/lib/decoding/import_section_parser.ex
@@ -5,15 +5,12 @@ defmodule WaspVM.Decoder.ImportSectionParser do
 
   @moduledoc false
 
-  def parse(module) do
-    {count, entries} =
-      module.sections
-      |> Map.get(2)
-      |> LEB128.decode_unsigned()
+  def parse(section) do
+    {count, entries} = LEB128.decode_unsigned(section)
 
     entries = if count > 0, do: parse_entries(entries), else: []
 
-    Map.put(module, :imports, entries)
+    {:imports, entries}
   end
 
   defp parse_entries(entries), do: parse_entries([], entries)

--- a/lib/decoding/memory_section_parser.ex
+++ b/lib/decoding/memory_section_parser.ex
@@ -3,11 +3,8 @@ defmodule WaspVM.Decoder.MemorySectionParser do
 
   @moduledoc false
 
-  def parse(module) do
-    {count, entries} =
-      module.sections
-      |> Map.get(5)
-      |> LEB128.decode_unsigned()
+  def parse(section) do
+    {count, entries} = LEB128.decode_unsigned(section)
 
     # Right now each module can have only 1 memory entry.
     # Might have to refactor this if a new version of Wasm
@@ -31,7 +28,7 @@ defmodule WaspVM.Decoder.MemorySectionParser do
         []
       end
 
-    Map.put(module, :memory, entries)
+    {:memory, entries}
   end
 
 end

--- a/lib/decoding/start_section_parser.ex
+++ b/lib/decoding/start_section_parser.ex
@@ -3,13 +3,10 @@ defmodule WaspVM.Decoder.StartSectionParser do
 
   @moduledoc false
 
-   def parse(module) do
-     {index, _entries} =
-       module.sections
-       |> Map.get(8)
-       |> LEB128.decode_unsigned()
+   def parse(section) do
+     {index, _entries} = LEB128.decode_unsigned(section)
 
-     Map.put(module, :start, index)
+     {:start, index}
    end
 
 end

--- a/lib/decoding/table_section_parser.ex
+++ b/lib/decoding/table_section_parser.ex
@@ -3,11 +3,8 @@ defmodule WaspVM.Decoder.TableSectionParser do
 
   @moduledoc false
 
-  def parse(module) do
-    {count, entries} =
-      module.sections
-      |> Map.get(4)
-      |> LEB128.decode_unsigned()
+  def parse(section) do
+    {count, entries} = LEB128.decode_unsigned(section)
 
     entries =
       # Not correct. Only parses first item out
@@ -29,7 +26,7 @@ defmodule WaspVM.Decoder.TableSectionParser do
         []
       end
 
-    Map.put(module, :table, entries)
+    {:table, entries}
   end
 
 end

--- a/lib/decoding/type_section_parser.ex
+++ b/lib/decoding/type_section_parser.ex
@@ -4,11 +4,8 @@ defmodule WaspVM.Decoder.TypeSectionParser do
 
   @moduledoc false
 
-  def parse(module) do
-    {count, entries} =
-      module.sections
-      |> Map.get(1)
-      |> LEB128.decode_unsigned()
+  def parse(section) do
+    {count, entries} = LEB128.decode_unsigned(section)
 
     entries =
       if count > 0 do
@@ -25,7 +22,7 @@ defmodule WaspVM.Decoder.TypeSectionParser do
         []
       end
 
-    Map.put(module, :types, entries)
+    {:types, entries}
   end
 
   defp parse_type_entry(entry) do

--- a/lib/wasp_vm.ex
+++ b/lib/wasp_vm.ex
@@ -37,7 +37,7 @@ defmodule WaspVM do
     Load a binary WebAssembly file (.wasm) as a module into the VM
   """
   @spec load_file(pid, String.t(), boolean) :: :ok
-  def load_file(ref, filename, parallel \\ false) do
+  def load_file(ref, filename, parallel \\ true) do
     GenServer.call(ref, {:load_module, Decoder.decode_file(filename, parallel)}, :infinity)
   end
 
@@ -45,7 +45,7 @@ defmodule WaspVM do
     Load a WebAssembly module directly from a binary into the VM
   """
   @spec load(pid, binary, boolean) :: :ok
-  def load(ref, binary, parallel \\ false) when is_binary(binary) do
+  def load(ref, binary, parallel \\ true) when is_binary(binary) do
     GenServer.call(ref, {:load_module, Decoder.decode(binary, parallel)}, :infinity)
   end
 

--- a/lib/wasp_vm.ex
+++ b/lib/wasp_vm.ex
@@ -36,17 +36,17 @@ defmodule WaspVM do
   @doc """
     Load a binary WebAssembly file (.wasm) as a module into the VM
   """
-  @spec load_file(pid, String.t()) :: :ok
-  def load_file(ref, filename) do
-    GenServer.call(ref, {:load_module, Decoder.decode_file(filename)}, :infinity)
+  @spec load_file(pid, String.t(), boolean) :: :ok
+  def load_file(ref, filename, parallel \\ false) do
+    GenServer.call(ref, {:load_module, Decoder.decode_file(filename, parallel)}, :infinity)
   end
 
   @doc """
     Load a WebAssembly module directly from a binary into the VM
   """
-  @spec load(pid, binary) :: :ok
-  def load(ref, binary) when is_binary(binary) do
-    GenServer.call(ref, {:load_module, Decoder.decode(binary)}, :infinity)
+  @spec load(pid, binary, boolean) :: :ok
+  def load(ref, binary, parallel \\ false) when is_binary(binary) do
+    GenServer.call(ref, {:load_module, Decoder.decode(binary, parallel)}, :infinity)
   end
 
   @doc """


### PR DESCRIPTION
Fixes #13 by allowing parallelism to be specified when loading Wasm into the VM. When calling `load_file/3` or `load/3`, the third parameter (defaults to true) specifies whether or not to decode the module's sections in parallel. 

Parallelism offers performance improvements in decoding speed on all but tiny file sizes. Here are some benchmarks:

For a ~8 KB file:
```
Name               ips        average  deviation         median         99th %
parallel          6.88      145.43 ms     ±1.29%      144.62 ms      150.27 ms
linear            5.53      180.89 ms     ±2.51%      179.94 ms      191.94 ms

Comparison:
parallel          6.88
linear            5.53 - 1.24x slower
```

For an 80 byte file:
```
Name               ips        average  deviation         median         99th %
linear         12.10 K       82.66 μs    ±64.40%          77 μs         181 μs
parallel        6.86 K      145.85 μs    ±22.02%         139 μs      259.54 μs

Comparison:
linear         12.10 K
parallel        6.86 K - 1.76x slower
```